### PR TITLE
[FEATURE] Introduce formatter component

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ following implementations are currently available:
 ### Formatter
 
 Formatters can be used to properly display a calculated
-[`Diff\DiffResult`](src/Diff/DiffResult.php). The following implementations are
-currently available:
+[`Diff\DiffResult`](src/Diff/DiffResult.php). Each formatter implements
+[`Formatter\Formatter`](src/Formatter/Formatter.php). The following implementations
+are currently available:
 
 - [`CliFormatter`](src/Formatter/CliFormatter.php) is used on command line. It
   displays the calculated diff with ANSI colors, targeting Symfony's console output.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Available options:
 
 ```php
 use CPSIT\Migrator\Diff;
+use CPSIT\Migrator\Formatter;
 use CPSIT\Migrator\Migrator;
 use CPSIT\Migrator\Resource;
 
@@ -67,26 +68,16 @@ $target = new Resource\Collector\DirectoryCollector('/path/to/current/revision/f
 // or just calculate a diff between the code bases
 $performMigrations = true;
 
-// Create differ and migrator
+// Create differ, migrator and formatter
 $differ = new Diff\Differ\GitDiffer();
 $migrator = new Migrator($differ, $performMigrations);
+$formatter = new Formatter\TextFormatter();
 
 // Migrate files in your base directory
 $diffResult = $migrator->migrate($source, $target, $base);
 
-// Print diff
-foreach ($diffResult->getDiffObjects() as $diffObject) {
-    echo '--- a/'.$diffObject->getOriginalPath().PHP_EOL;
-    echo '+++ b/'.$diffObject->getDestinationPath().PHP_EOL;
-
-    foreach ($diffObject->getChunks() as $diffChunk) {
-        echo $diffChunk->getHeaderLine().PHP_EOL;
-
-        foreach ($diffChunk as $diffChunkLine) {
-            echo $diffChunkLine.PHP_EOL;
-        }
-    }
-}
+// Format diff
+$formatter->format($diffResult);
 ```
 
 ## 🎢 Architecture
@@ -128,6 +119,18 @@ following implementations are currently available:
 
 - [`GitDiffer`](src/Diff/Differ/GitDiffer.php) uses the native Git binary to create
   diffs. This is done by the great library [`cypresslab/gitelephant`][1].
+
+### Formatter
+
+Formatters can be used to properly display a calculated
+[`Diff\DiffResult`](src/Diff/DiffResult.php). The following implementations are
+currently available:
+
+- [`CliFormatter`](src/Formatter/CliFormatter.php) is used on command line. It
+  displays the calculated diff with ANSI colors, targeting Symfony's console output.
+- [`TextFormatter`](src/Formatter/TextFormatter.php) can be used in other contexts
+  than command line, e.g. to properly display the calculated diff in case ANSI
+  colors are not available.
 
 ## 🧑‍💻 Contributing
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $formatter = new Formatter\TextFormatter();
 $diffResult = $migrator->migrate($source, $target, $base);
 
 // Format diff
-$formatter->format($diffResult);
+echo $formatter->format($diffResult);
 ```
 
 ## 🎢 Architecture

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -142,12 +142,10 @@ final class MigrateCommand extends Console\Command\Command
     {
         $formattedDiffResult = $this->formatter->format($diffResult);
 
-        if (null === $formattedDiffResult) {
-            return;
+        if (null !== $formattedDiffResult) {
+            $this->io->section('Changed files');
+            $this->io->writeln($formattedDiffResult);
         }
-
-        $this->io->section('Changed files');
-        $this->io->writeln($formattedDiffResult);
     }
 
     private function writePatchFile(string $patch): void
@@ -169,9 +167,11 @@ final class MigrateCommand extends Console\Command\Command
 
         $cwd = getcwd();
 
+        // @codeCoverageIgnoreStart
         if (false === $cwd) {
             throw new Console\Exception\RuntimeException('Unable to determine current working directory.', 1674654976);
         }
+        // @codeCoverageIgnoreEnd
 
         return Filesystem\Path::makeAbsolute($resource, $cwd);
     }

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -25,9 +25,9 @@ namespace CPSIT\Migrator\Command;
 
 use CPSIT\Migrator\Diff;
 use CPSIT\Migrator\Exception;
+use CPSIT\Migrator\Formatter;
 use CPSIT\Migrator\Migrator;
 use CPSIT\Migrator\Resource;
-use GitElephant\Objects;
 use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
@@ -46,6 +46,7 @@ final class MigrateCommand extends Console\Command\Command
 {
     private readonly Filesystem\Filesystem $filesystem;
     private Console\Style\SymfonyStyle $io;
+    private Formatter\Formatter $formatter;
 
     public function __construct(
         private readonly Migrator $migrator = new Migrator(),
@@ -84,6 +85,7 @@ final class MigrateCommand extends Console\Command\Command
     protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
     {
         $this->io = new Console\Style\SymfonyStyle($input, $output);
+        $this->formatter = new Formatter\CliFormatter();
     }
 
     /**
@@ -138,81 +140,14 @@ final class MigrateCommand extends Console\Command\Command
 
     private function decorateDiffResult(Diff\DiffResult $diffResult): void
     {
-        $diffObjects = $diffResult->getDiffObjects();
+        $formattedDiffResult = $this->formatter->format($diffResult);
 
-        // Early return if no files changed
-        if ([] === $diffObjects) {
+        if (null === $formattedDiffResult) {
             return;
         }
 
         $this->io->section('Changed files');
-
-        foreach ($diffObjects as $diffObject) {
-            $this->decorateDiffObjectHeader($diffObject);
-
-            foreach ($diffObject->getChunks() as $chunks) {
-                $this->io->writeln('<fg=cyan>'.$chunks->getHeaderLine().'</>');
-
-                /** @var Objects\Diff\DiffChunkLine $chunk */
-                foreach ($chunks as $chunk) {
-                    switch ($chunk::class) {
-                        case Objects\Diff\DiffChunkLineUnchanged::class:
-                            $this->io->writeln(' '.$chunk->getContent());
-                            break;
-
-                        case Objects\Diff\DiffChunkLineAdded::class:
-                            $this->io->writeln('<fg=green>+'.$chunk->getContent().'</>');
-                            break;
-
-                        case Objects\Diff\DiffChunkLineDeleted::class:
-                            $this->io->writeln('<fg=red>-'.$chunk->getContent().'</>');
-                            break;
-                    }
-                }
-            }
-
-            $this->io->newLine();
-        }
-    }
-
-    private function decorateDiffObjectHeader(Diff\DiffObject $diffObject): void
-    {
-        $srcPath = '<options=bold>--- a/'.$diffObject->getOriginalPath().'</>';
-        $destPath = '<options=bold>+++ b/'.$diffObject->getDestinationPath().'</>';
-
-        $this->io->writeln(
-            match ($diffObject->getMode()) {
-                Diff\DiffMode::Added => [
-                    '<options=bold>--- /dev/null</>',
-                    $destPath,
-                    '<fg=black;bg=green> ADDED </>',
-                ],
-                Diff\DiffMode::Copied => [
-                    $srcPath,
-                    $destPath,
-                    '<fg=black;bg=gray> COPIED </>',
-                ],
-                Diff\DiffMode::Deleted => [
-                    $srcPath,
-                    '<options=bold>+++ /dev/null</>',
-                    '<fg=black;bg=red> DELETED </>',
-                ],
-                Diff\DiffMode::Ignored => [
-                    $srcPath,
-                    '<options=bold>+++ /dev/null</>',
-                    '<fg=black;bg=gray> IGNORED </>',
-                ],
-                Diff\DiffMode::Renamed => [
-                    $srcPath,
-                    $destPath,
-                    '<fg=black;bg=yellow> RENAMED </>',
-                ],
-                default => [
-                    $srcPath,
-                    $destPath,
-                ],
-            },
-        );
+        $this->io->writeln($formattedDiffResult);
     }
 
     private function writePatchFile(string $patch): void

--- a/src/Formatter/CliFormatter.php
+++ b/src/Formatter/CliFormatter.php
@@ -95,27 +95,27 @@ final class CliFormatter implements Formatter
             Diff\DiffMode::Added => [
                 $this->decorateText($this->decorator->decorateOriginalPath(null), options: ['bold']),
                 $this->decorateText($destPath, options: ['bold']),
-                $this->decorateText(' ADDED ', 'green'),
+                $this->decorateText(' ADDED ', 'green', 'black'),
             ],
             Diff\DiffMode::Copied => [
                 $this->decorateText($srcPath, options: ['bold']),
                 $this->decorateText($destPath, options: ['bold']),
-                $this->decorateText(' COPIED ', 'gray'),
+                $this->decorateText(' COPIED ', 'gray', 'black'),
             ],
             Diff\DiffMode::Deleted => [
                 $this->decorateText($srcPath, options: ['bold']),
                 $this->decorateText($this->decorator->decorateDestinationPath(null), options: ['bold']),
-                $this->decorateText(' DELETED ', 'red'),
+                $this->decorateText(' DELETED ', 'red', 'black'),
             ],
             Diff\DiffMode::Ignored => [
                 $this->decorateText($srcPath, options: ['bold']),
                 $this->decorateText($this->decorator->decorateDestinationPath(null), options: ['bold']),
-                $this->decorateText(' IGNORED ', 'gray'),
+                $this->decorateText(' IGNORED ', 'gray', 'black'),
             ],
             Diff\DiffMode::Renamed => [
                 $this->decorateText($srcPath, options: ['bold']),
                 $this->decorateText($destPath, options: ['bold']),
-                $this->decorateText(' RENAMED ', 'yellow'),
+                $this->decorateText(' RENAMED ', 'yellow', 'black'),
             ],
             default => [
                 $this->decorateText($srcPath, options: ['bold']),
@@ -160,7 +160,7 @@ final class CliFormatter implements Formatter
     private function decorateText(
         string $text,
         string $backgroundColor = null,
-        string $foregroundColor = 'black',
+        string $foregroundColor = null,
         array $options = [],
     ): string {
         $tagAttributes = array_filter(

--- a/src/Formatter/CliFormatter.php
+++ b/src/Formatter/CliFormatter.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Formatter;
+
+use CPSIT\Migrator\Diff;
+use Generator;
+use GitElephant\Objects;
+
+use function implode;
+
+/**
+ * CliFormatter.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class CliFormatter implements Formatter
+{
+    public function format(Diff\DiffResult $diffResult): ?string
+    {
+        $diffObjects = $diffResult->getDiffObjects();
+        $outputLines = [];
+
+        // Early return if no files changed
+        if ([] === $diffObjects) {
+            return null;
+        }
+
+        foreach ($this->formatDiffObjects($diffObjects) as $diffObjectLine) {
+            $outputLines[] = $diffObjectLine;
+        }
+
+        return implode(PHP_EOL, $outputLines);
+    }
+
+    /**
+     * @param array<Diff\DiffObject> $diffObjects
+     *
+     * @return Generator<string>
+     */
+    private function formatDiffObjects(array $diffObjects): Generator
+    {
+        foreach ($diffObjects as $diffObject) {
+            yield from $this->formatDiffObjectHeader($diffObject);
+
+            foreach ($diffObject->getChunks() as $chunks) {
+                yield '<fg=cyan>'.$chunks->getHeaderLine().'</>';
+                yield from $this->formatDiffChunkLines($chunks->getLines());
+            }
+
+            yield '';
+        }
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    private function formatDiffObjectHeader(Diff\DiffObject $diffObject): Generator
+    {
+        $srcPath = '<options=bold>--- a/'.$diffObject->getOriginalPath().'</>';
+        $destPath = '<options=bold>+++ b/'.$diffObject->getDestinationPath().'</>';
+
+        yield from match ($diffObject->getMode()) {
+            Diff\DiffMode::Added => [
+                '<options=bold>--- /dev/null</>',
+                $destPath,
+                '<fg=black;bg=green> ADDED </>',
+            ],
+            Diff\DiffMode::Copied => [
+                $srcPath,
+                $destPath,
+                '<fg=black;bg=gray> COPIED </>',
+            ],
+            Diff\DiffMode::Deleted => [
+                $srcPath,
+                '<options=bold>+++ /dev/null</>',
+                '<fg=black;bg=red> DELETED </>',
+            ],
+            Diff\DiffMode::Ignored => [
+                $srcPath,
+                '<options=bold>+++ /dev/null</>',
+                '<fg=black;bg=gray> IGNORED </>',
+            ],
+            Diff\DiffMode::Renamed => [
+                $srcPath,
+                $destPath,
+                '<fg=black;bg=yellow> RENAMED </>',
+            ],
+            default => [
+                $srcPath,
+                $destPath,
+            ],
+        };
+    }
+
+    /**
+     * @param array<Objects\Diff\DiffChunkLine> $chunkLines
+     *
+     * @return Generator<string>
+     */
+    private function formatDiffChunkLines(array $chunkLines): Generator
+    {
+        foreach ($chunkLines as $chunkLine) {
+            switch ($chunkLine::class) {
+                case Objects\Diff\DiffChunkLineUnchanged::class:
+                    yield ' '.$chunkLine->getContent();
+                    break;
+
+                case Objects\Diff\DiffChunkLineAdded::class:
+                    yield '<fg=green>+'.$chunkLine->getContent().'</>';
+                    break;
+
+                case Objects\Diff\DiffChunkLineDeleted::class:
+                    yield '<fg=red>-'.$chunkLine->getContent().'</>';
+                    break;
+            }
+        }
+    }
+}

--- a/src/Formatter/Decorator/DiffDecorator.php
+++ b/src/Formatter/Decorator/DiffDecorator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Formatter\Decorator;
+
+use GitElephant\Objects;
+
+use function str_repeat;
+
+/**
+ * DiffDecorator.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class DiffDecorator
+{
+    public function decorateOriginalPath(?string $originalPath): string
+    {
+        if (null === $originalPath) {
+            $originalPath = '/dev/null';
+        } else {
+            $originalPath = 'a/'.$originalPath;
+        }
+
+        return $this->decoratePath($originalPath, '-');
+    }
+
+    public function decorateDestinationPath(?string $destinationPath): string
+    {
+        if (null === $destinationPath) {
+            $destinationPath = '/dev/null';
+        } else {
+            $destinationPath = 'b/'.$destinationPath;
+        }
+
+        return $this->decoratePath($destinationPath, '+');
+    }
+
+    public function decorateChunkLine(Objects\Diff\DiffChunkLine $chunkLine): ?string
+    {
+        return match ($chunkLine::class) {
+            Objects\Diff\DiffChunkLineUnchanged::class => ' '.$chunkLine->getContent(),
+            Objects\Diff\DiffChunkLineAdded::class => '+'.$chunkLine->getContent(),
+            Objects\Diff\DiffChunkLineDeleted::class => '-'.$chunkLine->getContent(),
+            default => null,
+        };
+    }
+
+    private function decoratePath(string $path, string $diffSign): string
+    {
+        return str_repeat($diffSign, 3).' '.$path;
+    }
+}

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Formatter;
+
+use CPSIT\Migrator\Diff;
+
+/**
+ * Formatter.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+interface Formatter
+{
+    public function format(Diff\DiffResult $diffResult): ?string;
+}

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Formatter;
+
+use CPSIT\Migrator\Diff;
+use Generator;
+use GitElephant\Objects;
+
+use function implode;
+
+/**
+ * TextFormatter.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TextFormatter implements Formatter
+{
+    private Decorator\DiffDecorator $decorator;
+
+    public function __construct()
+    {
+        $this->decorator = new Decorator\DiffDecorator();
+    }
+
+    public function format(Diff\DiffResult $diffResult): ?string
+    {
+        $diffObjects = $diffResult->getDiffObjects();
+        $outputLines = [];
+
+        // Early return if no files changed
+        if ([] === $diffObjects) {
+            return null;
+        }
+
+        foreach ($this->formatDiffObjects($diffObjects) as $diffObjectLine) {
+            $outputLines[] = $diffObjectLine;
+        }
+
+        return implode(PHP_EOL, $outputLines);
+    }
+
+    /**
+     * @param array<Diff\DiffObject> $diffObjects
+     *
+     * @return Generator<string>
+     */
+    private function formatDiffObjects(array $diffObjects): Generator
+    {
+        foreach ($diffObjects as $diffObject) {
+            yield from $this->formatDiffObjectHeader($diffObject);
+
+            foreach ($diffObject->getChunks() as $chunks) {
+                yield $chunks->getHeaderLine();
+                yield from $this->formatDiffChunkLines($chunks->getLines());
+            }
+
+            yield '';
+        }
+    }
+
+    /**
+     * @return Generator<string>
+     */
+    private function formatDiffObjectHeader(Diff\DiffObject $diffObject): Generator
+    {
+        $srcPath = $this->decorator->decorateOriginalPath($diffObject->getOriginalPath());
+        $destPath = $this->decorator->decorateDestinationPath($diffObject->getDestinationPath());
+
+        yield from match ($diffObject->getMode()) {
+            Diff\DiffMode::Added => [
+                $this->decorator->decorateOriginalPath(null),
+                $destPath,
+            ],
+            Diff\DiffMode::Deleted,
+            Diff\DiffMode::Ignored => [
+                $srcPath,
+                $this->decorator->decorateDestinationPath(null),
+            ],
+            default => [
+                $srcPath,
+                $destPath,
+            ],
+        };
+    }
+
+    /**
+     * @param array<Objects\Diff\DiffChunkLine> $chunkLines
+     *
+     * @return Generator<string>
+     */
+    private function formatDiffChunkLines(array $chunkLines): Generator
+    {
+        foreach ($chunkLines as $chunkLine) {
+            $decoratedChunkLine = $this->decorator->decorateChunkLine($chunkLine);
+
+            if (null !== $decoratedChunkLine) {
+                yield $decoratedChunkLine;
+            }
+        }
+    }
+}

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -37,7 +37,7 @@ use function implode;
  */
 final class TextFormatter implements Formatter
 {
-    private Decorator\DiffDecorator $decorator;
+    private readonly Decorator\DiffDecorator $decorator;
 
     public function __construct()
     {

--- a/tests/src/Diff/DiffResultTest.php
+++ b/tests/src/Diff/DiffResultTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\Migrator\Tests\Diff;
 
 use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
 use PHPUnit\Framework;
 
 /**
@@ -34,40 +35,28 @@ use PHPUnit\Framework;
  */
 final class DiffResultTest extends Framework\TestCase
 {
-    /**
-     * @var list<Src\Diff\DiffObject>
-     */
-    private array $diffObjects;
     private Src\Diff\DiffResult $subject;
 
     protected function setUp(): void
     {
-        $this->diffObjects = [
-            new Src\Diff\DiffObject(Src\Diff\DiffMode::Added, 'foo', 'foo', []),
-            new Src\Diff\DiffObject(Src\Diff\DiffMode::Deleted, 'baz', 'baz', []),
-        ];
-        $this->subject = new Src\Diff\DiffResult(
-            $this->diffObjects,
-            'foo',
-            Src\Diff\Outcome::failed('error'),
-        );
+        $this->subject = Tests\Fixtures\DataProvider\DiffResultProvider::createFailed();
     }
 
     #[Framework\Attributes\Test]
     public function getDiffObjectsReturnsDiffObjects(): void
     {
-        self::assertSame($this->diffObjects, $this->subject->getDiffObjects());
+        self::assertCount(3, $this->subject->getDiffObjects());
     }
 
     #[Framework\Attributes\Test]
     public function getPatchReturnsPatch(): void
     {
-        self::assertSame('foo', $this->subject->getPatch());
+        self::assertSame('###patch string###', $this->subject->getPatch());
     }
 
     #[Framework\Attributes\Test]
     public function getOutcomeReturnsOutcome(): void
     {
-        self::assertEquals(Src\Diff\Outcome::failed('error'), $this->subject->getOutcome());
+        self::assertEquals(Src\Diff\Outcome::failed('something went wrong'), $this->subject->getOutcome());
     }
 }

--- a/tests/src/Diff/Differ/GitDifferTest.php
+++ b/tests/src/Diff/Differ/GitDifferTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\Migrator\Tests\Diff\Differ;
 
 use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
 use GitElephant\Repository;
 use PHPUnit\Framework;
 use ReflectionProperty;
@@ -89,7 +90,7 @@ final class GitDifferTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function applyDiffThrowsExceptionIfDiffResultIsNotSuccessful(): void
     {
-        $diffResult = new Src\Diff\DiffResult([], 'foo', Src\Diff\Outcome::failed('error'));
+        $diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createFailed();
 
         $this->expectExceptionObject(Src\Exception\PatchFailureException::forConflictedDiff($diffResult));
 

--- a/tests/src/Exception/PatchFailureExceptionTest.php
+++ b/tests/src/Exception/PatchFailureExceptionTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\Migrator\Tests\Exception;
 
 use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
 use PHPUnit\Framework;
 
 /**
@@ -37,7 +38,7 @@ final class PatchFailureExceptionTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function createReturnsExceptionForInvalidType(): void
     {
-        $diffResult = new Src\Diff\DiffResult([], 'foo', Src\Diff\Outcome::failed('error'));
+        $diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createFailed();
 
         $actual = Src\Exception\PatchFailureException::forConflictedDiff($diffResult);
 
@@ -49,7 +50,7 @@ final class PatchFailureExceptionTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function createModifiesDiffResultIfGivenOutcomeIsSuccessful(): void
     {
-        $diffResult = new Src\Diff\DiffResult([], 'foo', Src\Diff\Outcome::successful());
+        $diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createSuccessful();
 
         $actual = Src\Exception\PatchFailureException::forConflictedDiff($diffResult);
 

--- a/tests/src/Fixtures/Classes/DummyDiffChunkLine.php
+++ b/tests/src/Fixtures/Classes/DummyDiffChunkLine.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Tests\Fixtures\Classes;
+
+use GitElephant\Objects;
+
+/**
+ * DummyDiffChunkLine.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class DummyDiffChunkLine extends Objects\Diff\DiffChunkLine
+{
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+    }
+}

--- a/tests/src/Fixtures/Classes/DummyDiffer.php
+++ b/tests/src/Fixtures/Classes/DummyDiffer.php
@@ -26,6 +26,7 @@ namespace CPSIT\Migrator\Tests\Fixtures\Classes;
 use CPSIT\Migrator\Diff;
 use CPSIT\Migrator\Exception;
 use CPSIT\Migrator\Resource;
+use CPSIT\Migrator\Tests;
 
 /**
  * DummyDiffer.
@@ -52,7 +53,7 @@ final class DummyDiffer implements Diff\Differ\Differ
             return $this->expectedResult;
         }
 
-        return new Diff\DiffResult([], 'dummy', Diff\Outcome::successful());
+        return Tests\Fixtures\DataProvider\DiffResultProvider::createSuccessful();
     }
 
     public function applyDiff(

--- a/tests/src/Fixtures/DataProvider/DiffResultProvider.php
+++ b/tests/src/Fixtures/DataProvider/DiffResultProvider.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Tests\Fixtures\DataProvider;
+
+use CPSIT\Migrator\Diff;
+use CPSIT\Migrator\Resource;
+
+use function array_rand;
+
+/**
+ * DiffResultProvider.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class DiffResultProvider
+{
+    public static function createFromFixtures(
+        Diff\Differ\Differ $differ = new Diff\Differ\GitDiffer(),
+    ): Diff\DiffResult {
+        return $differ->generateDiff(
+            new Resource\Collector\DirectoryCollector(self::getFixtureSource()),
+            new Resource\Collector\DirectoryCollector(self::getFixtureTarget()),
+            new Resource\Collector\DirectoryCollector(self::getFixtureBase()),
+        );
+    }
+
+    public static function createSuccessful(int $numberOfDiffObjects = 3): Diff\DiffResult
+    {
+        $diffObjects = self::createDiffObjects($numberOfDiffObjects);
+
+        return new Diff\DiffResult($diffObjects, '###patch string###', Diff\Outcome::successful());
+    }
+
+    public static function createFailed(int $numberOfDiffObjects = 3): Diff\DiffResult
+    {
+        $diffObjects = self::createDiffObjects($numberOfDiffObjects);
+
+        return new Diff\DiffResult($diffObjects, '###patch string###', Diff\Outcome::failed('something went wrong'));
+    }
+
+    public static function getFixtureSource(): string
+    {
+        return dirname(__DIR__).'/TestFiles/Source';
+    }
+
+    public static function getFixtureTarget(): string
+    {
+        return dirname(__DIR__).'/TestFiles/Target';
+    }
+
+    public static function getFixtureBase(): string
+    {
+        return dirname(__DIR__).'/TestFiles/Base';
+    }
+
+    /**
+     * @return list<Diff\DiffObject>
+     */
+    private static function createDiffObjects(int $numberOfDiffObjects): array
+    {
+        $diffObjects = [];
+        $diffModes = Diff\DiffMode::cases();
+
+        for ($i = 0; $i < $numberOfDiffObjects; ++$i) {
+            $diffObjects[] = new Diff\DiffObject(
+                $diffModes[array_rand($diffModes)],
+                '/foo/'.$i,
+                '/baz/'.$i,
+                [],
+            );
+        }
+
+        return $diffObjects;
+    }
+}

--- a/tests/src/Fixtures/DataProvider/DiffResultProvider.php
+++ b/tests/src/Fixtures/DataProvider/DiffResultProvider.php
@@ -26,7 +26,7 @@ namespace CPSIT\Migrator\Tests\Fixtures\DataProvider;
 use CPSIT\Migrator\Diff;
 use CPSIT\Migrator\Resource;
 
-use function array_rand;
+use function count;
 
 /**
  * DiffResultProvider.
@@ -87,7 +87,7 @@ final class DiffResultProvider
 
         for ($i = 0; $i < $numberOfDiffObjects; ++$i) {
             $diffObjects[] = new Diff\DiffObject(
-                $diffModes[array_rand($diffModes)],
+                $diffModes[$i % count($diffModes)],
                 '/foo/'.$i,
                 '/baz/'.$i,
                 [],

--- a/tests/src/Formatter/CliFormatterTest.php
+++ b/tests/src/Formatter/CliFormatterTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Tests\Formatter;
+
+use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
+use PHPUnit\Framework;
+
+/**
+ * CliFormatterTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class CliFormatterTest extends Framework\TestCase
+{
+    private Src\Formatter\CliFormatter $subject;
+    private Src\Diff\DiffResult $diffResult;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\Formatter\CliFormatter();
+        $this->diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createFromFixtures();
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatReturnsNullIfNoDiffObjectsAreAvailable(): void
+    {
+        $diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createSuccessful(0);
+
+        self::assertNull($this->subject->format($diffResult));
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatFormatsDiffObjectHeader(): void
+    {
+        $actual = $this->subject->format($this->diffResult);
+
+        self::assertIsString($actual);
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                '<fg=black;options=bold>--- a/composer.json</>',
+                '<fg=black;options=bold>+++ b/composer.json</>',
+            ]),
+            $actual,
+        );
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                '<fg=black;options=bold>--- a/.gitignore</>',
+                '<fg=black;options=bold>+++ /dev/null</>',
+                '<bg=red;fg=black> DELETED </>',
+            ]),
+            $actual,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatFormatsDiffChunk(): void
+    {
+        $actual = $this->subject->format($this->diffResult);
+
+        self::assertIsString($actual);
+        self::assertStringContainsString('<fg=cyan>@@ -4,6 +4,6 @@</>', $actual);
+        self::assertMatchesRegularExpression('#<fg=red>-\s+"phpunit/phpunit": "\^9\.5"</>#', $actual);
+        self::assertMatchesRegularExpression('#<fg=green>\+\s+"phpunit/phpunit": "\^10\.0"</>#', $actual);
+    }
+}

--- a/tests/src/Formatter/CliFormatterTest.php
+++ b/tests/src/Formatter/CliFormatterTest.php
@@ -60,15 +60,15 @@ final class CliFormatterTest extends Framework\TestCase
         self::assertIsString($actual);
         self::assertStringContainsString(
             implode(PHP_EOL, [
-                '<fg=black;options=bold>--- a/composer.json</>',
-                '<fg=black;options=bold>+++ b/composer.json</>',
+                '<options=bold>--- a/composer.json</>',
+                '<options=bold>+++ b/composer.json</>',
             ]),
             $actual,
         );
         self::assertStringContainsString(
             implode(PHP_EOL, [
-                '<fg=black;options=bold>--- a/.gitignore</>',
-                '<fg=black;options=bold>+++ /dev/null</>',
+                '<options=bold>--- a/.gitignore</>',
+                '<options=bold>+++ /dev/null</>',
                 '<bg=red;fg=black> DELETED </>',
             ]),
             $actual,

--- a/tests/src/Formatter/Decorator/DiffDecoratorTest.php
+++ b/tests/src/Formatter/Decorator/DiffDecoratorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Tests\Formatter\Decorator;
+
+use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
+use Generator;
+use GitElephant\Objects;
+use PHPUnit\Framework;
+
+/**
+ * DiffDecoratorTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class DiffDecoratorTest extends Framework\TestCase
+{
+    private Src\Formatter\Decorator\DiffDecorator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\Formatter\Decorator\DiffDecorator();
+    }
+
+    #[Framework\Attributes\Test]
+    public function decorateOriginalPathReturnsDevNullOnNullishOriginalPath(): void
+    {
+        self::assertSame('--- /dev/null', $this->subject->decorateOriginalPath(null));
+    }
+
+    #[Framework\Attributes\Test]
+    public function decorateOriginalPathReturnsDecoratedOriginalPath(): void
+    {
+        self::assertSame('--- a/foo/baz', $this->subject->decorateOriginalPath('foo/baz'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function decorateDestinationPathReturnsDevNullOnNullishDestinationPath(): void
+    {
+        self::assertSame('+++ /dev/null', $this->subject->decorateDestinationPath(null));
+    }
+
+    #[Framework\Attributes\Test]
+    public function decorateDestinationPathReturnsDecoratedDestinationPath(): void
+    {
+        self::assertSame('+++ b/foo/baz', $this->subject->decorateDestinationPath('foo/baz'));
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('decorateChunkLineReturnsDecoratedDiffChunkLineDataProvider')]
+    public function decorateChunkLineReturnsDecoratedDiffChunkLine(
+        Objects\Diff\DiffChunkLine $chunkLine,
+        ?string $expected,
+    ): void {
+        self::assertSame($expected, $this->subject->decorateChunkLine($chunkLine));
+    }
+
+    /**
+     * @return Generator<string, array{Objects\Diff\DiffChunkLine, string|null}>
+     */
+    public static function decorateChunkLineReturnsDecoratedDiffChunkLineDataProvider(): Generator
+    {
+        yield 'added' => [
+            new Objects\Diff\DiffChunkLineAdded(123, 'foo'),
+            '+foo',
+        ];
+        yield 'deleted' => [
+            new Objects\Diff\DiffChunkLineDeleted(123, 'foo'),
+            '-foo',
+        ];
+        yield 'unchanged' => [
+            new Objects\Diff\DiffChunkLineUnchanged(123, 123, 'foo'),
+            ' foo',
+        ];
+        yield 'dummy' => [
+            new Tests\Fixtures\Classes\DummyDiffChunkLine('foo'),
+            null,
+        ];
+    }
+}

--- a/tests/src/Formatter/TextFormatterTest.php
+++ b/tests/src/Formatter/TextFormatterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "cpsit/migrator".
+ *
+ * Copyright (C) 2023 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Migrator\Tests\Formatter;
+
+use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
+use PHPUnit\Framework;
+
+/**
+ * TextFormatterTest.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TextFormatterTest extends Framework\TestCase
+{
+    private Src\Formatter\TextFormatter $subject;
+    private Src\Diff\DiffResult $diffResult;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\Formatter\TextFormatter();
+        $this->diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createFromFixtures();
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatReturnsNullIfNoDiffObjectsAreAvailable(): void
+    {
+        $diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createSuccessful(0);
+
+        self::assertNull($this->subject->format($diffResult));
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatFormatsDiffObjectHeader(): void
+    {
+        $actual = $this->subject->format($this->diffResult);
+
+        self::assertIsString($actual);
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                '--- a/composer.json',
+                '+++ b/composer.json',
+            ]),
+            $actual,
+        );
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                '--- a/.gitignore',
+                '+++ /dev/null',
+            ]),
+            $actual,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatFormatsDiffChunk(): void
+    {
+        $actual = $this->subject->format($this->diffResult);
+
+        self::assertIsString($actual);
+        self::assertStringContainsString('@@ -4,6 +4,6 @@', $actual);
+        self::assertStringContainsString('"phpunit/phpunit": "^9.5"', $actual);
+        self::assertStringContainsString('"phpunit/phpunit": "^10.0"', $actual);
+    }
+}

--- a/tests/src/Helper/FilesystemHelperTest.php
+++ b/tests/src/Helper/FilesystemHelperTest.php
@@ -24,8 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\Migrator\Tests\Helper;
 
 use CPSIT\Migrator as Src;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework;
 
 /**
  * FilesystemHelperTest.
@@ -33,9 +32,9 @@ use PHPUnit\Framework\TestCase;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-final class FilesystemHelperTest extends TestCase
+final class FilesystemHelperTest extends Framework\TestCase
 {
-    #[Test]
+    #[Framework\Attributes\Test]
     public function getNewTemporaryDirectoryReturnsUniqueTemporaryDirectory(): void
     {
         $tempDir = sys_get_temp_dir();

--- a/tests/src/MigratorTest.php
+++ b/tests/src/MigratorTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace CPSIT\Migrator\Tests;
 
 use CPSIT\Migrator as Src;
+use CPSIT\Migrator\Tests;
 use PHPUnit\Framework;
 
 /**
@@ -44,7 +45,7 @@ final class MigratorTest extends Framework\TestCase
     protected function setUp(): void
     {
         $this->differ = new Fixtures\Classes\DummyDiffer();
-        $this->diffResult = new Src\Diff\DiffResult([], 'foo', Src\Diff\Outcome::successful());
+        $this->diffResult = Tests\Fixtures\DataProvider\DiffResultProvider::createSuccessful();
         $this->source = new Src\Resource\Collector\ArrayCollector([]);
         $this->target = new Src\Resource\Collector\ArrayCollector([]);
         $this->base = new Src\Resource\Collector\DirectoryCollector(__DIR__);


### PR DESCRIPTION
This PR introduces a new `Formatter` component. The previous diff formatting is moved from the console command to a dedicated `CliFormatter`. An additional `TextFormatter` is added that can be used in combination with the PHP API.

More formatters will follow in the future.

Resolves: #29