### PR TITLE
[BUGFIX] Avoid exception when trying to commit empty commits

### DIFF
--- a/src/Diff/Differ/GitDiffer.php
+++ b/src/Diff/Differ/GitDiffer.php
@@ -180,7 +180,7 @@ final class GitDiffer implements Differ
      */
     private function calculateDiffObjects(Status\Status $status): array
     {
-        $diff = $this->repository->commit('Add changed files')->getDiff('HEAD', 'HEAD~1');
+        $diff = $this->repository->commit('Add changed files', allowEmpty: true)->getDiff('HEAD', 'HEAD~1');
         $diffObjects = [];
 
         /** @var Status\StatusFile $statusFile */


### PR DESCRIPTION
If no changes were made between base and target resources, the `GitDiffer` may perform empty commits. Thus, empty commits should be explicitly allowed, streamlining the commit behavior with base and source resources.