### PR TITLE
[BUGFIX] Avoid usage of `ReflectionProperty::setAccessible()`

### DIFF
--- a/tests/src/Diff/Differ/GitDifferTest.php
+++ b/tests/src/Diff/Differ/GitDifferTest.php
@@ -122,7 +122,6 @@ final class GitDifferTest extends Framework\TestCase
     private function getRepositoryPathFromReflection(): string
     {
         $reflectionProperty = new ReflectionProperty($this->subject, 'repository');
-        $reflectionProperty->setAccessible(true);
         $repository = $reflectionProperty->getValue($this->subject);
 
         self::assertInstanceOf(Repository::class, $repository);


### PR DESCRIPTION
Calling `ReflectionProperty::setAccessible()` has no effect since PHP 8.1.0. Thus, it can be safely removed.