### PR TITLE
[TASK] Require rector/rector ^0.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"phpstan/phpstan-strict-rules": "^1.5",
 		"phpstan/phpstan-symfony": "^1.2",
 		"phpunit/phpunit": "^10.1",
-		"rector/rector": "^0.15.21 || ^0.16.0"
+		"rector/rector": "^0.16"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbae0084ef4fdfd19dd5eaedec1c8a75",
+    "content-hash": "606f482c245014d392931052a7041a46",
     "packages": [
         {
             "name": "cypresslab/gitelephant",


### PR DESCRIPTION
This PR upgrades the minimum supported version of rector/rector to 0.16.0.