### PR TITLE
[BUGFIX] Remove obsolete PHPUnit rector set list

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -46,6 +46,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
         PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
-        PHPUnitSetList::PHPUNIT_YIELD_DATA_PROVIDER,
     ]);
 };


### PR DESCRIPTION
The Constant `PHPUNIT_YIELD_DATA_PROVIDER` in `PHPUnitSetList` refers to a non-existent rule. It was migrated recently to rector:

```php
# rector-phpunit/src/Set/PHPUnitSetList.php:67
public const PHPUNIT_YIELD_DATA_PROVIDER = __DIR__ . '/../../config/sets/phpunit-yield-data-provider.php';
```

I move to remove that rule from the rector configuration.