### PR TITLE
[TASK] Switch from `@PSR2` to `@PER-CS`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -25,7 +25,7 @@ $config = new \PhpCsFixer\Config();
 
 $config
     ->setRules([
-        '@PSR2' => true,
+        '@PER-CS' => true,
         '@Symfony' => true,
         'global_namespace_import' => [
             'import_classes' => true,

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",
 		"ergebnis/composer-normalize": "^2.30",
-		"friendsofphp/php-cs-fixer": "^3.14",
+		"friendsofphp/php-cs-fixer": "^3.29",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.10",
 		"phpstan/phpstan-phpunit": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7c2d09e96a14a2a663099ebd48783a3",
+    "content-hash": "5544c76707176cfaea74b3a318f77eb1",
     "packages": [
         {
             "name": "cypresslab/gitelephant",

--- a/src/Diff/DiffObject.php
+++ b/src/Diff/DiffObject.php
@@ -41,8 +41,7 @@ final class DiffObject
         private readonly ?string $originalPath,
         private readonly ?string $destinationPath,
         private readonly array $chunks,
-    ) {
-    }
+    ) {}
 
     public function getMode(): DiffMode
     {

--- a/src/Diff/DiffResult.php
+++ b/src/Diff/DiffResult.php
@@ -38,8 +38,7 @@ final class DiffResult
         private readonly array $diffObjects,
         private readonly string $patch,
         private readonly Outcome $outcome,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<DiffObject>

--- a/src/Diff/Outcome.php
+++ b/src/Diff/Outcome.php
@@ -34,8 +34,7 @@ final class Outcome
     private function __construct(
         private readonly bool $successful,
         private readonly ?string $message = null,
-    ) {
-    }
+    ) {}
 
     public static function successful(): self
     {

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -29,6 +29,4 @@ namespace CPSIT\Migrator\Exception;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-abstract class Exception extends \Exception
-{
-}
+abstract class Exception extends \Exception {}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -34,8 +34,7 @@ final class Migrator
     public function __construct(
         private readonly Diff\Differ\Differ $differ = new Diff\Differ\GitDiffer(),
         private bool $performMigrations = true,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception\PatchFailureException

--- a/src/Resource/Collector/ArrayCollector.php
+++ b/src/Resource/Collector/ArrayCollector.php
@@ -39,8 +39,7 @@ final class ArrayCollector implements CollectorInterface
      */
     public function __construct(
         private readonly array $collection,
-    ) {
-    }
+    ) {}
 
     public function collect(): array
     {


### PR DESCRIPTION
This PR changes the default PHP-CS-Fixer ruleset from `@PSR2` to `@PER-CS`.