### PR TITLE
[TASK] Use shared PHP-CS-Fixer configuration

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -22,38 +22,14 @@ declare(strict_types=1);
  */
 
 $config = new \PhpCsFixer\Config();
-
-$config
-    ->setRules([
-        '@PER-CS' => true,
-        '@Symfony' => true,
-        'global_namespace_import' => [
-            'import_classes' => true,
-            'import_functions' => true,
-        ],
-        'ordered_imports' => [
-            'imports_order' => [
-                'const',
-                'class',
-                'function',
-            ],
-        ],
-        'trailing_comma_in_multiline' => [
-            'elements' => [
-                'arguments',
-                'arrays',
-                'match',
-                'parameters',
-            ],
-        ],
-    ])
-;
-
 $config->getFinder()
     ->files()
     ->name(['*.php', 'migrator'])
     ->in(__DIR__)
     ->ignoreVCSIgnored(true)
 ;
+
+$ruleset = new \CPSIT\PhpCsFixerConfig\Rule\DefaultRuleset();
+$ruleset->apply($config);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",
+		"cpsit/php-cs-fixer-config": "^1.1",
 		"ergebnis/composer-normalize": "^2.30",
 		"friendsofphp/php-cs-fixer": "^3.29",
 		"phpstan/extension-installer": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec41fd0669839c7c7cdd9a6c63581540",
+    "content-hash": "ba96810d70f2a6c659d9cc09d1b0205d",
     "packages": [
         {
             "name": "cypresslab/gitelephant",
@@ -1376,6 +1376,60 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "cpsit/php-cs-fixer-config",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CPS-IT/php-cs-fixer-config.git",
+                "reference": "6bc0b94688dc21e897e3f6297b02b43f6bea9755"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CPS-IT/php-cs-fixer-config/zipball/6bc0b94688dc21e897e3f6297b02b43f6bea9755",
+                "reference": "6bc0b94688dc21e897e3f6297b02b43f6bea9755",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^1.8 || ^2.0",
+                "ergebnis/composer-normalize": "^2.41",
+                "phpstan/extension-installer": "^1.3",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "^10.5",
+                "rector/rector": "^0.18.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CPSIT\\PhpCsFixerConfig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elias Häußler",
+                    "email": "e.haeussler@familie-redlich.de",
+                    "homepage": "https://www.cps-it.de",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Shared PHP-CS-Fixer configuration for CPS projects",
+            "support": {
+                "issues": "https://github.com/CPS-IT/php-cs-fixer-config/issues",
+                "source": "https://github.com/CPS-IT/php-cs-fixer-config/tree/1.1.0"
+            },
+            "time": "2023-12-29T10:59:18+00:00"
         },
         {
             "name": "ergebnis/composer-normalize",

--- a/src/Diff/DiffObject.php
+++ b/src/Diff/DiffObject.php
@@ -41,8 +41,7 @@ final class DiffObject
         private readonly ?string $originalPath,
         private readonly ?string $destinationPath,
         private readonly array $chunks,
-    ) {
-    }
+    ) {}
 
     public function getMode(): DiffMode
     {

--- a/src/Diff/DiffResult.php
+++ b/src/Diff/DiffResult.php
@@ -38,8 +38,7 @@ final class DiffResult
         private readonly array $diffObjects,
         private readonly string $patch,
         private readonly Outcome $outcome,
-    ) {
-    }
+    ) {}
 
     /**
      * @return list<DiffObject>

--- a/src/Diff/Outcome.php
+++ b/src/Diff/Outcome.php
@@ -34,8 +34,7 @@ final class Outcome
     private function __construct(
         private readonly bool $successful,
         private readonly ?string $message = null,
-    ) {
-    }
+    ) {}
 
     public static function successful(): self
     {

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -29,6 +29,4 @@ namespace CPSIT\Migrator\Exception;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
  */
-abstract class Exception extends \Exception
-{
-}
+abstract class Exception extends \Exception {}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -34,8 +34,7 @@ final class Migrator
     public function __construct(
         private readonly Diff\Differ\Differ $differ = new Diff\Differ\GitDiffer(),
         private bool $performMigrations = true,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception\PatchFailureException

--- a/src/Resource/Collector/ArrayCollector.php
+++ b/src/Resource/Collector/ArrayCollector.php
@@ -39,8 +39,7 @@ final class ArrayCollector implements CollectorInterface
      */
     public function __construct(
         private readonly array $collection,
-    ) {
-    }
+    ) {}
 
     public function collect(): array
     {


### PR DESCRIPTION
This PR requires the `cpsit/php-cs-fixer-config` package which provides shared configuration for PHP-CS-Fixer.