### PR TITLE
[TASK] Use parallel execution in PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-$config = new \PhpCsFixer\Config();
-$config->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
+$config = new PhpCsFixer\Config();
+$config->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 $config->getFinder()
     ->files()
     ->name(['*.php', 'migrator'])
@@ -31,7 +31,7 @@ $config->getFinder()
     ->ignoreDotFiles(false)
 ;
 
-$ruleset = new \CPSIT\PhpCsFixerConfig\Rule\DefaultRuleset();
+$ruleset = new CPSIT\PhpCsFixerConfig\Rule\DefaultRuleset();
 $ruleset->apply($config);
 
 return $config;

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
  */
 
 $config = new \PhpCsFixer\Config();
+$config->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 $config->getFinder()
     ->files()
     ->name(['*.php', 'migrator'])

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -28,6 +28,7 @@ $config->getFinder()
     ->name(['*.php', 'migrator'])
     ->in(__DIR__)
     ->ignoreVCSIgnored(true)
+    ->ignoreDotFiles(false)
 ;
 
 $ruleset = new \CPSIT\PhpCsFixerConfig\Rule\DefaultRuleset();

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"armin/editorconfig-cli": "^1.6 || ^2.0",
 		"cpsit/php-cs-fixer-config": "^1.1",
 		"ergebnis/composer-normalize": "^2.30",
+		"friendsofphp/php-cs-fixer": "^3.57",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.10",
 		"phpstan/phpstan-phpunit": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30b5a92399fcc8d4311f41aead5ea3f6",
+    "content-hash": "2ec76e278868f43c4d1543656683f25a",
     "packages": [
         {
             "name": "cypresslab/gitelephant",


### PR DESCRIPTION
This PR enables parallel execution in PHP-CS-Fixer and optimizes configuration a little bit.